### PR TITLE
Refactor project list into reusable components

### DIFF
--- a/frontend/src/components/projects/ProjectCard.tsx
+++ b/frontend/src/components/projects/ProjectCard.tsx
@@ -1,0 +1,40 @@
+'use client';
+
+import React from 'react';
+
+export interface Project {
+  id: string;
+  name: string;
+  title: string;
+  taskCount: number;
+  createdAt: string;
+}
+
+interface ProjectCardProps {
+  project: Project;
+}
+
+export const ProjectCard: React.FC<ProjectCardProps> = ({ project }) => (
+  <div
+    className="group relative rounded-2xl bg-gradient-to-br from-blue-500/15 to-purple-500/5 border border-blue-400/20 p-4 hover:scale-105 hover:shadow-xl hover:shadow-blue-500/15 transition-all duration-300 cursor-pointer"
+  >
+    <div className="absolute inset-0 rounded-2xl bg-gradient-to-br from-blue-500/8 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300" />
+    <div className="relative">
+      <div className="flex items-start justify-between mb-2">
+        <div className="flex-1">
+          <h4 className="font-semibold text-white group-hover:text-white/90 transition-colors">
+            {project.title}
+          </h4>
+          <p className="text-sm text-white/60 font-mono">{project.name}</p>
+        </div>
+        <span className="text-xs bg-gradient-to-r from-blue-500/30 to-purple-500/30 px-2 py-1 rounded-full text-white/80 border border-blue-400/20">
+          {project.taskCount} tasks
+        </span>
+      </div>
+      <div className="text-xs text-white/50">
+        Created {new Date(project.createdAt).toLocaleDateString()}
+      </div>
+    </div>
+  </div>
+);
+

--- a/frontend/src/components/projects/ProjectsView.tsx
+++ b/frontend/src/components/projects/ProjectsView.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+import React from 'react';
+import { GlassButton } from '../ui/GlassButton';
+import { ProjectCard, type Project } from './ProjectCard';
+
+interface ProjectsViewProps {
+  projects: Project[];
+  onCreateProject?: () => void;
+}
+
+export const ProjectsView: React.FC<ProjectsViewProps> = ({ projects, onCreateProject }) => {
+  if (projects.length === 0) {
+    return (
+      <div className="text-center py-8">
+        <p className="text-white/60 text-sm mb-4">No projects yet</p>
+        {onCreateProject && (
+          <GlassButton
+            size="sm"
+            onClick={onCreateProject}
+            className="rounded-lg"
+          >
+            Create Your First Project
+          </GlassButton>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      {projects.map((project) => (
+        <ProjectCard key={project.id} project={project} />
+      ))}
+    </div>
+  );
+};
+

--- a/frontend/src/components/sidebar/Sidebar.tsx
+++ b/frontend/src/components/sidebar/Sidebar.tsx
@@ -3,14 +3,8 @@
 import React, { useState } from 'react';
 import { cn } from '@/lib/utils';
 import { GlassButton } from '../ui/GlassButton';
-
-interface Project {
-  id: string;
-  name: string;
-  title: string;
-  taskCount: number;
-  createdAt: string;
-}
+import { ProjectsView } from '../projects/ProjectsView';
+import type { Project } from '../projects/ProjectCard';
 
 interface SidebarProps {
   isOpen: boolean;
@@ -233,45 +227,10 @@ export const Sidebar: React.FC<SidebarProps> = ({
                 </GlassButton>
               </div>
 
-              <div className="space-y-3">
-                {projects.map((project) => (
-                  <div
-                    key={project.id}
-                    className="group relative rounded-2xl bg-gradient-to-br from-blue-500/15 to-purple-500/5 border border-blue-400/20 p-4 hover:scale-105 hover:shadow-xl hover:shadow-blue-500/15 transition-all duration-300 cursor-pointer"
-                  >
-                    <div className="absolute inset-0 rounded-2xl bg-gradient-to-br from-blue-500/8 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300" />
-                    <div className="relative">
-                      <div className="flex items-start justify-between mb-2">
-                        <div className="flex-1">
-                          <h4 className="font-semibold text-white group-hover:text-white/90 transition-colors">
-                            {project.title}
-                          </h4>
-                          <p className="text-sm text-white/60 font-mono">{project.name}</p>
-                        </div>
-                        <span className="text-xs bg-gradient-to-r from-blue-500/30 to-purple-500/30 px-2 py-1 rounded-full text-white/80 border border-blue-400/20">
-                          {project.taskCount} tasks
-                        </span>
-                      </div>
-                      <div className="text-xs text-white/50">
-                        Created {new Date(project.createdAt).toLocaleDateString()}
-                      </div>
-                    </div>
-                  </div>
-                ))}
-              </div>
-
-              {projects.length === 0 && (
-                <div className="text-center py-8">
-                  <p className="text-white/60 text-sm mb-4">No projects yet</p>
-                  <GlassButton
-                    size="sm"
-                    onClick={() => setShowCreateProject(true)}
-                    className="rounded-lg"
-                  >
-                    Create Your First Project
-                  </GlassButton>
-                </div>
-              )}
+              <ProjectsView
+                projects={projects}
+                onCreateProject={() => setShowCreateProject(true)}
+              />
             </div>
           )}
         </div>

--- a/frontend/src/hooks/useApi.ts
+++ b/frontend/src/hooks/useApi.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 
 // Generic API function


### PR DESCRIPTION
## Summary
- extract project card UI into a reusable `ProjectCard` component
- add `ProjectsView` to render project lists and handle empty state
- refactor sidebar to use the new components instead of inline markup

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: 8 errors, 3 warnings)*
- `npm run build` *(fails: Failed to fetch fonts `Geist` and `Geist Mono`)*

------
https://chatgpt.com/codex/tasks/task_e_68b275446334832cbcf78c3483ddaa26