### PR TITLE
chore: set Go 1.22 and make Fiber direct

### DIFF
--- a/backend/go.mod
+++ b/backend/go.mod
@@ -1,10 +1,10 @@
 module backend
 
-go 1.24.5
+go 1.22
 
 require (
 	github.com/andybalholm/brotli v1.1.0 // indirect
-	github.com/gofiber/fiber/v2 v2.52.9 // indirect
+	github.com/gofiber/fiber/v2 v2.52.9
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/klauspost/compress v1.17.9 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect


### PR DESCRIPTION
## Summary
- update Go module to version 1.22
- make github.com/gofiber/fiber/v2 a direct dependency

## Testing
- `go mod tidy` *(fails: Get "https://proxy.golang.org/github.com/gofiber/fiber/v2/@v/v2.52.9.zip": Forbidden)*
- `go test ./...` *(fails: github.com/gofiber/fiber/v2@v2.52.9: Get "https://proxy.golang.org/github.com/gofiber/fiber/v2/@v/v2.52.9.zip": Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b30ca94e54832ca91f95055302dd29