### PR TITLE
Fix CORS middleware invocation

### DIFF
--- a/backend/cmd/main.go
+++ b/backend/cmd/main.go
@@ -1,13 +1,13 @@
-package main	
+package main
 
 import (
-    "github.com/gofiber/fiber/v2"
-    "github.com/gofiber/fiber/v2/middleware/cors"
+	"github.com/gofiber/fiber/v2"
+	"github.com/gofiber/fiber/v2/middleware/cors"
 )
 
 func main() {
 	app := fiber.New()
-	app.Use((cors.New()))
+	app.Use(cors.New())
 
 	app.Get("/hello", func(c *fiber.Ctx) error {
 		return c.SendString("Hello, Fiber!")


### PR DESCRIPTION
## Summary
- simplify Fiber CORS middleware initialization

## Testing
- `go fmt backend/cmd/main.go`
- `go test ./...` *(fails: go.mod requires go >= 1.24.5 and toolchain download is forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b30c9bbd98832cbce53a2c57cdd0dd