### PR TITLE
Introduce HTTP dependencies struct

### DIFF
--- a/backend/internal/interface/http/dependencies.go
+++ b/backend/internal/interface/http/dependencies.go
@@ -1,0 +1,31 @@
+package http
+
+import (
+	"backend/internal/interface/http/middleware"
+	"backend/internal/interface/http/prioritize"
+	"backend/internal/interface/http/task"
+)
+
+// Dependencies groups services required by HTTP routes.
+//
+// It bundles all external services used by the HTTP layer so that
+// router construction only needs a single parameter.
+type Dependencies struct {
+	auth              middleware.AuthService
+	TaskService       *task.Service
+	PrioritizeService *prioritize.Service
+}
+
+// NewDependencies creates a new Dependencies instance.
+func NewDependencies(a middleware.AuthService, t *task.Service, p *prioritize.Service) Dependencies {
+	return Dependencies{
+		auth:              a,
+		TaskService:       t,
+		PrioritizeService: p,
+	}
+}
+
+// Auth returns the authentication service.
+func (d Dependencies) Auth() middleware.AuthService {
+	return d.auth
+}

--- a/backend/internal/interface/http/middleware/auth.go
+++ b/backend/internal/interface/http/middleware/auth.go
@@ -2,9 +2,17 @@ package middleware
 
 import "github.com/gofiber/fiber/v2"
 
+// AuthService defines behaviour required for authentication operations.
+// VerifyToken should validate the supplied token and return user and tenant
+// information or an error when the token is invalid.
+type AuthService interface {
+	VerifyToken(token string) (any, any, error)
+}
+
+// AuthMiddleware authenticates requests using the provided service.
 func AuthMiddleware(authSvc AuthService) fiber.Handler {
 	return func(c *fiber.Ctx) error {
-		user, tenant, err := authSvc.VerifyToken(c. Get("Authorization"))
+		user, tenant, err := authSvc.VerifyToken(c.Get("Authorization"))
 		if err != nil {
 			return fiber.ErrUnauthorized
 		}

--- a/backend/internal/interface/http/prioritize/routes.go
+++ b/backend/internal/interface/http/prioritize/routes.go
@@ -1,0 +1,11 @@
+package prioritize
+
+import "github.com/gofiber/fiber/v2"
+
+// Service handles prioritization operations.
+type Service struct{}
+
+// RegisterRoutes wires prioritization routes to the provided router.
+func RegisterRoutes(r fiber.Router, svc *Service) {
+	// TODO: implement prioritize handlers
+}

--- a/backend/internal/interface/http/router.go
+++ b/backend/internal/interface/http/router.go
@@ -2,10 +2,13 @@ package http
 
 import (
 	"backend/internal/interface/http/middleware"
+	"backend/internal/interface/http/prioritize"
+	"backend/internal/interface/http/task"
 
 	"github.com/gofiber/fiber/v2"
 )
 
+// Build registers API routes using the provided dependencies.
 func Build(app *fiber.App, deps Dependencies) {
 	api := app.Group("/api", middleware.AuthMiddleware(deps.Auth()))
 

--- a/backend/internal/interface/http/task/routes.go
+++ b/backend/internal/interface/http/task/routes.go
@@ -2,10 +2,10 @@ package task
 
 import "github.com/gofiber/fiber/v2"
 
-func RegisterRoutes(r *fiber.Route, svc *task.Service) {
-	h := fiber.Handler{Svc: svc}
-	r.Get("/", h.List)
-	r.Post("/", h.Create)
-	r.Put("/:id", h.Update)
-	r.Delete("/:id", h.Delete)
+// Service handles task related operations.
+type Service struct{}
+
+// RegisterRoutes wires task routes to the provided router.
+func RegisterRoutes(r fiber.Router, svc *Service) {
+	// TODO: implement task handlers
 }


### PR DESCRIPTION
## Summary
- add backend HTTP `Dependencies` struct bundling required services
- wire router through the new struct and document usage
- stub prioritize and task routes and define `AuthService` interface

## Testing
- `go test ./...` *(fails: go.mod requires go >= 1.24.5 (running go 1.24.3; GOTOOLCHAIN=local))*


------
https://chatgpt.com/codex/tasks/task_e_68b30ca7b324832c82416b2dac53d24c