### PR TITLE
Use log.Fatal when starting Fiber server

### DIFF
--- a/backend/cmd/main.go
+++ b/backend/cmd/main.go
@@ -1,8 +1,10 @@
-package main	
+package main
 
 import (
-    "github.com/gofiber/fiber/v2"
-    "github.com/gofiber/fiber/v2/middleware/cors"
+	"log"
+
+	"github.com/gofiber/fiber/v2"
+	"github.com/gofiber/fiber/v2/middleware/cors"
 )
 
 func main() {
@@ -13,5 +15,5 @@ func main() {
 		return c.SendString("Hello, Fiber!")
 	})
 
-	app.Listen(":3001")
+	log.Fatal(app.Listen(":3001"))
 }


### PR DESCRIPTION
## Summary
- ensure Fiber server startup errors are reported by wrapping `app.Listen` with `log.Fatal`
- add missing `log` import

## Testing
- `gofmt -w backend/cmd/main.go`
- `go test ./...` *(fails: downloading go1.24.5 forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b30c7fe01c832ca8d9c3219bda12a5